### PR TITLE
add 3rd argument to Delete method

### DIFF
--- a/ftp/fs/azure/azureBlob/azureBlob.go
+++ b/ftp/fs/azure/azureBlob/azureBlob.go
@@ -92,5 +92,5 @@ func (b *azureBlob) Clone() fs.File {
 }
 
 func (b azureBlob) Delete() error {
-	return b.client.DeleteBlob(b.path, b.name)
+	return b.client.DeleteBlob(b.path, b.name, nil)
 }


### PR DESCRIPTION
@MindFlavor 18 days ago, DeleteBlob API seemed to be changed to require 3rd argument as the following.
https://github.com/Azure/azure-sdk-for-go/commit/42f58e46b3527b6f3338f7033cf1eabf62bd6b89

`b.client.DeleteBlob` should have 3 arguments in order to build this application.
