### PR TITLE
Add nested directories feature

### DIFF
--- a/ftp/fs/azure/azureFS.go
+++ b/ftp/fs/azure/azureFS.go
@@ -105,7 +105,11 @@ func (pfs *azureFS) Get(filename string) (fs.File, error) {
 	}
 
 	// else blob
-	return azureBlob.New(toks[1], toks[0], 0, time.Now(), 0666, pfs.client), nil
+	props, err := pfs.client.GetBlobProperties(toks[0], strings.Join(toks[1:], "/"))
+	if err != nil {
+		return nil, err
+	}
+	return azureBlob.New(strings.Join(toks[1:], "/"), toks[0], props.ContentLength, parseAzureTime(props.LastModified), 0666, pfs.client), nil
 }
 
 func (pfs *azureFS) New(filename string, isDirectory bool) (fs.File, error) {

--- a/ftp/session/commands.go
+++ b/ftp/session/commands.go
@@ -385,7 +385,7 @@ func (ses *Session) processTYPE(tokens []string) bool {
 		return false
 	}
 
-	ses.sendStatement("202 Type I and A are the only one supported")
+	ses.sendStatement(fmt.Sprintf("200 Type set to %s", strings.ToUpper(tokens[1])))
 	return false
 }
 

--- a/ftp/session/session.go
+++ b/ftp/session/session.go
@@ -41,6 +41,7 @@ const (
 	MKD
 	RMD
 	REST
+	NLST
 
 //	AUTH auth must be handled manually
 //	PROT auth must be handled manually
@@ -67,6 +68,7 @@ var commands = []string{
 	"MKD",
 	"RMD",
 	"REST",
+	"NLST",
 	//	"AUTH", auth must be handled manually
 	//	"PROT", auth must be handled manually
 }
@@ -182,6 +184,8 @@ func (ses *Session) Handle() error {
 			terminateProcessing = newCmdList(ses, tokens, ses.processDELE).requireAuth().resetUSER().resetREST().Execute()
 		case commands[REST]:
 			terminateProcessing = newCmdList(ses, tokens, ses.processREST).requireAuth().requirePASV().resetUSER().resetREST().Execute()
+		case commands[NLST]:
+			terminateProcessing = newCmdList(ses, tokens, ses.processNLST).requireAuth().requirePASV().resetUSER().resetREST().Execute()
 		case "AUTH":
 			terminateProcessing = newCmdList(ses, tokens, ses.processAUTH).resetUSER().resetREST().Execute()
 		case "PROT":


### PR DESCRIPTION
This request adds following supports:
- nested `LIST`
- nested `CWD` and `MKD`
- `NLST`

Nested directories become available by empty (zero-sized) blobs and `Prefix`/`Delimiter` API parameters. This method is used commonly in S3 or Swift, and Azure portal also can show directory hierarchy. By the nested directories support, `NLST`/`LIST` commands are more useful for many users.

Also, this request includes some misc changes such as return code of `TYPE`.
