### PR TITLE
Catch signal and check port availability

### DIFF
--- a/ftp/fs/azure/azureBlob/blobWriter.go
+++ b/ftp/fs/azure/azureBlob/blobWriter.go
@@ -32,7 +32,7 @@ func NewBlockBlobWriter(b *azureBlob) (io.WriteCloser, error) {
 }
 
 func (w *blockblobWriter) Write(p []byte) (int, error) {
-	nextBlock64 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%4d", w.cnt)))
+	nextBlock64 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%5d", w.cnt)))
 	//	log.WithFields(log.Fields{"len(p)": len(p), "w.b.Path()": w.b.Path(), "w.b.Name()": w.b.Name(), "nextBlock64": nextBlock64, "w.cnt": w.cnt}).Debug("azureBlob::blockblobWriter::Write called")
 
 	w.cnt++

--- a/ftp/session/commands.go
+++ b/ftp/session/commands.go
@@ -201,7 +201,7 @@ func (ses *Session) processSTOR(tokens []string) bool {
 		}
 		defer file.Close()
 
-		buf := make([]byte, 1024*256)
+		buf := make([]byte, 1024*1024*4)
 
 		ses.sendStatement(fmt.Sprintf("150 Opening BINARY mode data connection for %s.", f.Name()))
 

--- a/main.go
+++ b/main.go
@@ -7,9 +7,10 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -122,5 +123,26 @@ func main() {
 
 	srv.Accept()
 
-	fmt.Scanf("%s")
+	signal_chan := make(chan os.Signal, 1)
+	var code int
+	signal.Notify(signal_chan)
+	for {
+		s := <-signal_chan
+		switch s {
+		case syscall.SIGINT:
+			log.WithFields(log.Fields{"signal": "SIGINT"}).Warn("main::main " + s.String())
+			code = 0
+		case syscall.SIGTERM:
+			log.WithFields(log.Fields{"signal": "SIGTERM"}).Warn("main::main " + s.String())
+			code = 0
+		case syscall.SIGPIPE:
+			log.WithFields(log.Fields{"signal": "SIGPIPE"}).Warn("main::main " + s.String())
+			continue
+		default:
+			log.Error("main::main Unknown signal (" + s.String() + ")")
+			code = 1
+		}
+		break
+	}
+	os.Exit(code)
 }


### PR DESCRIPTION
This pull request makes networking stable when putting big objects. Bigger block size (4MiB) can improve upload speed as well. Daemon-ization is useful for long running use-case.

Includes:
- Add support for bigger objects (db9b6865)
- More stable networking (858c4a4f)
- Catch signals to daemonize (eb505451)
