### PR TITLE
Supports 50000 blocks of 100MiB

### DIFF
--- a/ftp/session/commands.go
+++ b/ftp/session/commands.go
@@ -201,7 +201,7 @@ func (ses *Session) processSTOR(tokens []string) bool {
 		}
 		defer file.Close()
 
-		buf := make([]byte, 1024*1024*4)
+		buf := make([]byte, 1024*1024*100)
 
 		ses.sendStatement(fmt.Sprintf("150 Opening BINARY mode data connection for %s.", f.Name()))
 


### PR DESCRIPTION
From Azure Storage perspective, the block BLOB storage has "50,000 blocks x size of block".  Lately, the block size was raised up to 100 MB, so the current limitation is "50,000 blocks x 100 MB = approx.. 4.75TB"; however, it was previously 4 MB; thus, it was 195 GB.

This PR will change the behaviour to use large blob (100MB per block).

Understanding Block Blobs, Append Blobs, and Page Blobs:
https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/understanding-block-blobs--append-blobs--and-page-blobs

Azure Storage Scalability and Performance Target:
https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets