### PR TITLE
fix: avoid case-insensitive import collision (Sirupsen/logrus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The main features are:
 * FTP Secure implicit
 * File system agnostic
 * Azure nested directory support (thanks to [Shuichiro MAKIGAKI](https://github.com/shuichiro-makigaki))
-* Pluggable logging system (thanks to [logrus](https://github.com/Sirupsen/logrus))
+* Pluggable logging system (thanks to [logrus](https://github.com/sirupsen/logrus))
 
 ### Implemented commands
 

--- a/ftp/datachannel/datachannel.go
+++ b/ftp/datachannel/datachannel.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp/portassigner"
 )
 

--- a/ftp/fs/azure/azureBlob/azureBlob.go
+++ b/ftp/fs/azure/azureBlob/azureBlob.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/mindflavor/ftpserver2/ftp/fs"

--- a/ftp/fs/azure/azureBlob/blobWriter.go
+++ b/ftp/fs/azure/azureBlob/blobWriter.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 )

--- a/ftp/fs/azure/azureContainer/azureContainer.go
+++ b/ftp/fs/azure/azureContainer/azureContainer.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/mindflavor/ftpserver2/ftp/fs"

--- a/ftp/fs/azure/azureFS.go
+++ b/ftp/fs/azure/azureFS.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 	"github.com/mindflavor/ftpserver2/ftp/fs/azure/azureBlob"
 	"github.com/mindflavor/ftpserver2/ftp/fs/azure/azureContainer"

--- a/ftp/fs/localFS/physicalFS.go
+++ b/ftp/fs/localFS/physicalFS.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 	"github.com/mindflavor/ftpserver2/ftp/fs/localFS/physicalFile"
 	"github.com/mindflavor/ftpserver2/identity"

--- a/ftp/fs/localFS/physicalFile/physicalFile.go
+++ b/ftp/fs/localFS/physicalFile/physicalFile.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 )

--- a/ftp/ftpserver.go
+++ b/ftp/ftpserver.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 	"github.com/mindflavor/ftpserver2/ftp/portassigner"
 	"github.com/mindflavor/ftpserver2/ftp/session"

--- a/ftp/portassigner/portassigner.go
+++ b/ftp/portassigner/portassigner.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/goserializer"
 )
 

--- a/ftp/session/cmdlist.go
+++ b/ftp/session/cmdlist.go
@@ -3,7 +3,7 @@ package session
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type cmdlist struct {

--- a/ftp/session/commands.go
+++ b/ftp/session/commands.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type processEntry func(tokens []string) bool

--- a/ftp/session/securableConn/securableConn.go
+++ b/ftp/session/securableConn/securableConn.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Conn interface exposes the method that will

--- a/ftp/session/session.go
+++ b/ftp/session/session.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp/datachannel"
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 	"github.com/mindflavor/ftpserver2/ftp/portassigner"

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/mindflavor/ftpserver2/ftp"
 	"github.com/mindflavor/ftpserver2/ftp/fs"
 	"github.com/mindflavor/ftpserver2/ftp/fs/azure"


### PR DESCRIPTION
This avoids problems with "go build" if you have other packages on your system that use
https://github.com/sirupsen/logrus (lower case).